### PR TITLE
Updated github workflow for docker to build for multiple architectures

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -1,4 +1,4 @@
-name: PHP-CS-Fixer syle check
+name: PHP-CS-Fixer style check
 
 on: [push]
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,14 +9,38 @@ on:
       - v*.*.*
 
 jobs:
-  build:
+  multi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - name: Publish to Docker Hub
-        uses: roy-bongers/Publish-Docker-Github-Action@master
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
         with:
-          name: rbongers/certbot-dns-transip
+          images: rbongers/certbot-dns-transip
+          tag-sha: false
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          tag_semver: true
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,4 +1,4 @@
-name: Run PHPUnit & PHPCS syle check
+name: Run PHPUnit & PHPCS style check
 
 on: [push]
 


### PR DESCRIPTION
Hi,

noticed when trying to use this on raspi there is no arm based docker image.
updated docker workflow to allow for creation of multiple architecture images.
already uploaded new images to own dockerhub page - bassmeets/certbot-dns-transip
Please see if the versioning also works like you want it to be.

Again thanks for this software, has greatly helped me getting ssl certs for my internal domain.

