### PR TITLE
Fetch nameservers from TransIP API instead of doing a DNS query

### DIFF
--- a/src/CertbotDns01/Certbot/Dns01ManualHookHandler.php
+++ b/src/CertbotDns01/Certbot/Dns01ManualHookHandler.php
@@ -126,7 +126,7 @@ class Dns01ManualHookHandler
         $updatedRecords = 0;
 
         $dnsRecord = $challengeRecord->getFullRecordName();
-        $nameservers = $this->getNameServers($challengeRecord->getDomain());
+        $nameservers = $this->provider->getNameservers($challengeRecord->getDomain());
         $totalNameservers = count($nameservers);
 
         $this->logger->info(sprintf('Waiting until nameservers (%s) are up-to-date', implode(', ', $nameservers)));

--- a/src/CertbotDns01/Certbot/Dns01ManualHookHandler.php
+++ b/src/CertbotDns01/Certbot/Dns01ManualHookHandler.php
@@ -204,11 +204,6 @@ class Dns01ManualHookHandler
         return rtrim('_acme-challenge.' . $subDomain, '.');
     }
 
-    private function getNameServers(string $domain): array
-    {
-        return array_column(dns_get_record($domain, DNS_NS), 'target');
-    }
-
     private function getSubDomain(string $baseDomain, string $domain): string
     {
         return rtrim(substr($domain, 0, strrpos($domain, $baseDomain)), '.');

--- a/src/CertbotDns01/Providers/Interfaces/ProviderInterface.php
+++ b/src/CertbotDns01/Providers/Interfaces/ProviderInterface.php
@@ -20,4 +20,9 @@ interface ProviderInterface
      * Return a simple array containing the domain names that can be managed via the API.
      */
     public function getDomainNames(): iterable;
+
+    /**
+     * Return all nameservers for a given domain.
+     */
+    public function getNameservers(string $domainName): array;
 }

--- a/src/CertbotDns01/Providers/TransIp/TransIp.php
+++ b/src/CertbotDns01/Providers/TransIp/TransIp.php
@@ -7,6 +7,7 @@ use RoyBongers\CertbotDns01\Certbot\ChallengeRecord;
 use RoyBongers\CertbotDns01\Config;
 use RoyBongers\CertbotDns01\Providers\Interfaces\ProviderInterface;
 use Transip\Api\Library\Entity\Domain\DnsEntry;
+use Transip\Api\Library\Entity\Domain\Nameserver;
 use Transip\Api\Library\TransipAPI;
 
 class TransIp implements ProviderInterface
@@ -82,6 +83,17 @@ class TransIp implements ProviderInterface
         $this->logger->debug(sprintf('Domain names available: %s', implode(', ', $this->domainNames)));
 
         return $this->domainNames;
+    }
+
+    public function getNameservers(string $domainName): array
+    {
+        $nameServers = $this->getTransIpApiClient()
+            ->domainNameserver()
+            ->getByDomainName($domainName);
+
+        return array_map(function (Nameserver $nameserver) {
+            return $nameserver->getHostname();
+        }, $nameServers);
     }
 
     public function getTransIpApiClient(): TransipAPI

--- a/src/CertbotDns01/Providers/TransIp/TransIp.php
+++ b/src/CertbotDns01/Providers/TransIp/TransIp.php
@@ -87,13 +87,13 @@ class TransIp implements ProviderInterface
 
     public function getNameservers(string $domainName): array
     {
-        $nameServers = $this->getTransIpApiClient()
+        $nameservers = $this->getTransIpApiClient()
             ->domainNameserver()
             ->getByDomainName($domainName);
 
         return array_map(function (Nameserver $nameserver) {
             return $nameserver->getHostname();
-        }, $nameServers);
+        }, $nameservers);
     }
 
     public function getTransIpApiClient(): TransipAPI

--- a/tests/CertbotDns01/Certbot/AuthHookTest.php
+++ b/tests/CertbotDns01/Certbot/AuthHookTest.php
@@ -15,6 +15,8 @@ use RoyBongers\CertbotDns01\Certbot\Requests\ManualHookRequest;
 use RoyBongers\CertbotDns01\Providers\Interfaces\ProviderInterface;
 use RuntimeException;
 use Symfony\Bridge\PhpUnit\DnsMock;
+use Transip\Api\Library\Entity\AbstractEntity;
+use Transip\Api\Library\Entity\Domain\Nameserver;
 
 class AuthHookTest extends TestCase
 {
@@ -41,6 +43,9 @@ class AuthHookTest extends TestCase
             ->with(Matchers::equalTo($expectedChallengeRecord))
             ->once();
 
+        $this->provider->shouldReceive('getNameservers')
+            ->andReturn($this->createNameserverResponse());
+
         // mock DNSQuery class
         $dnsAnswer = $this->createDnsAnswer('domain.com', 'AfricanOrEuropeanSwallow');
         $this->dnsQuery->shouldReceive('Query')->andReturn($dnsAnswer);
@@ -65,6 +70,9 @@ class AuthHookTest extends TestCase
         $this->provider->shouldReceive('createChallengeDnsRecord')
             ->with(Matchers::equalTo($expectedChallengeRecord))
             ->once();
+
+        $this->provider->shouldReceive('getNameservers')
+            ->andReturn($this->createNameserverResponse());
 
         // mock DNSQuery class
         $dnsAnswer = $this->createDnsAnswer('sub.domain.com', 'AfricanOrEuropeanSwallow');
@@ -93,6 +101,9 @@ class AuthHookTest extends TestCase
 
         $this->provider->shouldReceive('createChallengeDnsRecord');
 
+        $this->provider->shouldReceive('getNameservers')
+            ->andReturn($this->createNameserverResponse());
+
         // mock DNSQuery class
         $dnsAnswer = $this->createDnsAnswer('domain.com', 'HowDoYouKnowSoMuchAboutSwallows');
         $this->dnsQuery->shouldReceive('Query')->andReturn($dnsAnswer);
@@ -119,6 +130,15 @@ class AuthHookTest extends TestCase
         $dnsAnswer->addResult($dnsResult);
 
         return $dnsAnswer;
+    }
+
+    private function createNameserverResponse(): array
+    {
+        return [
+            'ns0.transip.net',
+            'ns1.transip.nl',
+            'ns2.transip.eu'
+        ];
     }
 
     public function setUp(): void

--- a/tests/CertbotDns01/Certbot/AuthHookTest.php
+++ b/tests/CertbotDns01/Certbot/AuthHookTest.php
@@ -15,8 +15,6 @@ use RoyBongers\CertbotDns01\Certbot\Requests\ManualHookRequest;
 use RoyBongers\CertbotDns01\Providers\Interfaces\ProviderInterface;
 use RuntimeException;
 use Symfony\Bridge\PhpUnit\DnsMock;
-use Transip\Api\Library\Entity\AbstractEntity;
-use Transip\Api\Library\Entity\Domain\Nameserver;
 
 class AuthHookTest extends TestCase
 {
@@ -137,7 +135,7 @@ class AuthHookTest extends TestCase
         return [
             'ns0.transip.net',
             'ns1.transip.nl',
-            'ns2.transip.eu'
+            'ns2.transip.eu',
         ];
     }
 


### PR DESCRIPTION
Getting the name servers by performing a DNS query seems to cause problems. They can also be fetched from the TransIP api. This is a possible fix for https://github.com/roy-bongers/certbot-transip-dns-01-validator/issues/115